### PR TITLE
chore(deps): bump https://github.com/Genomcore/jx-http-watch-pipeline-activity.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,3 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [Genomcore/jx-quickstart-1](https://github.com/Genomcore/jx-quickstart-1.git) |  | []() | 
+[Genomcore/jx-http-watch-pipeline-activity](https://github.com/Genomcore/jx-http-watch-pipeline-activity.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -5,3 +5,9 @@ dependencies:
   url: https://github.com/Genomcore/jx-quickstart-1.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: Genomcore
+  repo: jx-http-watch-pipeline-activity
+  url: https://github.com/Genomcore/jx-http-watch-pipeline-activity.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/genomcore-jx-http-watch-pipeline-activity-sr.yaml
+++ b/repositories/templates/genomcore-jx-http-watch-pipeline-activity-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: Genomcore
+    provider: github
+    repository: jx-http-watch-pipeline-activity
+  name: genomcore-jx-http-watch-pipeline-activity
+spec:
+  description: Imported application for Genomcore/jx-http-watch-pipeline-activity
+  httpCloneURL: https://github.com/Genomcore/jx-http-watch-pipeline-activity.git
+  org: Genomcore
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-http-watch-pipeline-activity
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/Genomcore/jx-http-watch-pipeline-activity.git


### PR DESCRIPTION
Update [Genomcore/jx-http-watch-pipeline-activity](https://github.com/Genomcore/jx-http-watch-pipeline-activity.git) 

Command run was `jx create quickstart`